### PR TITLE
Convert suggestions to annotations

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -3,7 +3,7 @@
 [![Circle CI](https://circleci.com/gh/Financial-Times/post-publication-combiner/tree/master.png?style=shield)](https://circleci.com/gh/Financial-Times/post-publication-combiner/tree/master)[![Go Report Card](https://goreportcard.com/badge/github.com/Financial-Times/post-publication-combiner)](https://goreportcard.com/report/github.com/Financial-Times/post-publication-combiner) [![Coverage Status](https://coveralls.io/repos/github/Financial-Times/post-publication-combiner/badge.svg)](https://coveralls.io/github/Financial-Times/post-publication-combiner)
 
 ## Introduction
-This service builds combined messages (content + v1 annotations) based on events received from PostMetadataPublicationEvents or PostPublicationEvents.  
+This service builds combined messages (content + annotations) based on events received from PostConceptAnnotations or PostPublicationEvents.  
 The combined message is then sent to the CombinedPostPublicationEvents kafka queue.
 
 This is a combination point for synchronizing the content and the metadata publish flows.
@@ -33,25 +33,7 @@ In order to install, execute the following steps:
 
 1. Run the binary (using the `help` flag to see the available optional arguments):
 
-        $GOPATH/bin/post-publication-combiner [--help]
-   
-The available parameters are: 
-* contentTopic
-* metadataTopic
-* combinedTopic
-* kafkaProxyAddress
-* kafkaContentTopicConsumerGroup
-* kafkaMetadataTopicConsumerGroup
-* kafkaProxyHeader
-* graphiteTCPAddress
-* graphitePrefix
-* logMetrics
-* docStoreBaseURL - document-store-api base url (http://localhost:8080/__document-store-api)
-* docStoreApiEndpoint - the endpoint for content retrieval (/content/{uuid})
-* publicAnnotationsApiBaseURL - public-annotations-api base url (http://localhost:8080/__public-annotations-api)
-* publicAnnotationsApiEndpoint - the endpoint for metadata retrieval (/content/{uuid}/annotations/{platformVersion})
-* whitelistedMetadataOriginSystemHeaders - Origin-System-Ids that are supported to be processed from the PostPublicationEvents queue
-* whitelistedContentURIs - Space separated list with content URI substrings - to identify accepted content types
+        $GOPATH/bin/post-publication-combiner
 
 Please check --help for more details.
 

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	})
 	metadataTopic := app.String(cli.StringOpt{
 		Name:   "metadataTopic",
-		Value:  "PostMetadataPublicationEvents",
+		Value:  "PostConceptAnnotations",
 		EnvVar: "KAFKA_METADATA_TOPIC_NAME",
 	})
 	combinedTopic := app.String(cli.StringOpt{

--- a/model/metadata.go
+++ b/model/metadata.go
@@ -1,7 +1,7 @@
 package model
 
 type Annotations struct {
-	Annotations []Annotation `json:"suggestions"`
+	Annotations []Annotation `json:"annotations"`
 	UUID        string       `json:"uuid"`
 }
 

--- a/processor/msg_processor_test.go
+++ b/processor/msg_processor_test.go
@@ -277,7 +277,7 @@ func TestProcessMetadataMsg_Forwarder_Errors(t *testing.T) {
 func TestProcessMetadataMsg_Successfully_Forwarded(t *testing.T) {
 	m := consumer.Message{
 		Headers: map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"},
-		Body:    `{"uuid":"some_uuid","annotation":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
+		Body:    `{"uuid":"some_uuid","annotations":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
 	}
 
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service", "http://cmdb.ft.com/systems/methode-web-pub"}

--- a/processor/msg_processor_test.go
+++ b/processor/msg_processor_test.go
@@ -230,7 +230,7 @@ func TestProcessMetadataMsg_SupportedOrigin_Unmarshall_Error(t *testing.T) {
 func TestProcessMetadataMsg_Combiner_Errors(t *testing.T) {
 	m := consumer.Message{
 		Headers: map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"},
-		Body:    `{"uuid":"some_uuid","suggestions":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
+		Body:    `{"uuid":"some_uuid","annotations":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
 	}
 
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service", "http://cmdb.ft.com/systems/methode-web-pub"}
@@ -252,7 +252,7 @@ func TestProcessMetadataMsg_Combiner_Errors(t *testing.T) {
 func TestProcessMetadataMsg_Forwarder_Errors(t *testing.T) {
 	m := consumer.Message{
 		Headers: map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"},
-		Body:    `{"uuid":"some_uuid","suggestions":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
+		Body:    `{"uuid":"some_uuid","annotations":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
 	}
 
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service", "http://cmdb.ft.com/systems/methode-web-pub"}
@@ -277,7 +277,7 @@ func TestProcessMetadataMsg_Forwarder_Errors(t *testing.T) {
 func TestProcessMetadataMsg_Successfully_Forwarded(t *testing.T) {
 	m := consumer.Message{
 		Headers: map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"},
-		Body:    `{"uuid":"some_uuid","suggestions":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
+		Body:    `{"uuid":"some_uuid","annotation":[{"ID":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","PrefLabel":"Barclays","Types":["http://base-url/core/Thing","http://base-url/concept/Concept"],"Predicate":"http://base-url/about","ApiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","TmeIDs":["tme_id1"],"UUIDs":["80bec524-8c75-4d0f-92fa-abce3962d995","factset-generated-uuid"],"PlatformVersion":"v1"}]}`,
 	}
 
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service", "http://cmdb.ft.com/systems/methode-web-pub"}


### PR DESCRIPTION
As part of the platinum-ise annotations work, we need to convert every suggestion coming from V1 systems to annotations, because these were already validated by editorial.