### PR TITLE
Mark as non-resilient, reduce severity

### DIFF
--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -40,7 +40,7 @@ func checkKafkaProxyProducerConnectivity(h *HealthcheckHandler) health.Check {
 		BusinessImpact:   "Can't write CombinedPostPublicationEvents messages to queue. Indexing for search won't work.",
 		Name:             "Check connectivity to the kafka-proxy",
 		PanicGuide:       "https://dewey.ft.com/post-publication-combiner.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "CombinedPostPublicationEvents messages can't be forwarded to the queue. Check if kafka-proxy is reachable.",
 		Checker:          h.producer.ConnectivityCheck,
 	}
@@ -51,7 +51,7 @@ func checkKafkaProxyConsumerConnectivity(h *HealthcheckHandler) health.Check {
 		BusinessImpact:   "Can't process PostPublicationEvents and PostMetadataPublicationEvents messages. Indexing for search won't work.",
 		Name:             "Check connectivity to the kafka-proxy",
 		PanicGuide:       "https://dewey.ft.com/post-publication-combiner.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "PostPublicationEvents and PostMetadataPublicationEvents messages are not received from the queue. Check if kafka-proxy is reachable.",
 		Checker:          h.consumer.ConnectivityCheck,
 	}
@@ -62,7 +62,7 @@ func checkDocumentStoreAPIHealthcheck(h *HealthcheckHandler) health.Check {
 		BusinessImpact:   "CombinedPostPublication messages can't be constructed. Indexing for content search won't work.",
 		Name:             "Check connectivity to document-store-api",
 		PanicGuide:       "https://dewey.ft.com/post-publication-combiner.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "Document-store-api is not reachable. Messages can't be successfully constructed, neither forwarded.",
 		Checker:          h.checkIfDocumentStoreIsReachable,
 	}
@@ -73,7 +73,7 @@ func checkPublicAnnotationsAPIHealthcheck(h *HealthcheckHandler) health.Check {
 		BusinessImpact:   "CombinedPostPublication messages can't be constructed. Indexing for content search won't work.",
 		Name:             "Check connectivity to public-annotations-api",
 		PanicGuide:       "https://dewey.ft.com/post-publication-combiner.html",
-		Severity:         1,
+		Severity:         2,
 		TechnicalSummary: "Public-annotations-api is not reachable. Messages can't be successfully constructed, neither forwarded.",
 		Checker:          h.checkIfPublicAnnotationsAPIIsReachable,
 	}

--- a/helm/post-publication-combiner/templates/service.yaml
+++ b/helm/post-publication-combiner/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{.Values.service.name}}
     visualize: "true" 
     hasHealthcheck: "{{ .Values.service.hasHealthcheck }}" 
+    isResilient: "{{ .Values.service.isResilient }}"
 spec:
   ports: 
     - port: 8080 

--- a/helm/post-publication-combiner/values.yaml
+++ b/helm/post-publication-combiner/values.yaml
@@ -4,6 +4,7 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder.
   hasHealthcheck: "true"
+  isResilient: "false"
 replicaCount: 2
 image:
   repository: coco/post-publication-combiner


### PR DESCRIPTION
- this service isn't resilient: both pods read from kafka using the same consumer group - this means only one of them is actually receiving the messages; if the pod which isn't receiving the messages stops, that's not problem, but if the pod who is actually receiving the messages stops working, then the other pod will not pick up messages either
- by marking it as non-resilient, the upp-aggregate-healthcheck (any versions which include this [PR](https://github.com/Financial-Times/upp-aggregate-healthcheck/pull/22)) will report the highest severity of any failed pods as the severity for the service 
- reduced the severity from 1 to 2 so any failures in this service will not turn dashing red