### PR TITLE
Fix an issue where Central Banking content was not filtered.

### DIFF
--- a/helm/post-publication-combiner/templates/deployment.yaml
+++ b/helm/post-publication-combiner/templates/deployment.yaml
@@ -76,8 +76,8 @@ spec:
               key: msk.kafka.broker.url
         - name: OPEN_POLICY_AGENT_ADDRESS
           value: {{ .Values.env.OPEN_POLICY_AGENT_ADDRESS }}
-        - name: OPEN_POLICY_AGENT_POLICY_PATH
-          value: {{ .Values.env.OPEN_POLICY_AGENT_POLICY_PATH }}
+        - name: OPEN_POLICY_AGENT_KAFKA_INGEST_PATH
+          value: {{ .Values.env.OPEN_POLICY_AGENT_KAFKA_INGEST_PATH }}
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/helm/post-publication-combiner/templates/deployment.yaml
+++ b/helm/post-publication-combiner/templates/deployment.yaml
@@ -76,8 +76,10 @@ spec:
               key: msk.kafka.broker.url
         - name: OPEN_POLICY_AGENT_ADDRESS
           value: {{ .Values.env.OPEN_POLICY_AGENT_ADDRESS }}
-        - name: OPEN_POLICY_AGENT_KAFKA_INGEST_PATH
-          value: {{ .Values.env.OPEN_POLICY_AGENT_KAFKA_INGEST_PATH }}
+        - name: OPEN_POLICY_AGENT_KAFKA_INGEST_CONTENT_PATH
+          value: {{ .Values.env.OPEN_POLICY_AGENT_KAFKA_INGEST_CONTENT_PATH }}
+        - name: OPEN_POLICY_AGENT_KAFKA_INGEST_METADATA_PATH
+          value: {{ .Values.env.OPEN_POLICY_AGENT_KAFKA_INGEST_METADATA_PATH }}
         ports:
         - containerPort: 8080
         livenessProbe:

--- a/helm/post-publication-combiner/values.yaml
+++ b/helm/post-publication-combiner/values.yaml
@@ -37,4 +37,5 @@ env:
   WHITELISTED_METADATA_ORIGIN_SYSTEM_HEADERS: "http://cmdb.ft.com/systems/pac, http://cmdb.ft.com/systems/next-video-editor"
   WHITELISTED_CONTENT_TYPES: "Article, Video, MediaResource, Audio, ContentPackage, LiveBlogPackage, LiveBlogPost, ContentCollection, ImageSet, Image, Graphic, LiveEvent, Clip, ClipSet, ,"
   OPEN_POLICY_AGENT_ADDRESS: "http://localhost:8181"
-  OPEN_POLICY_AGENT_KAFKA_INGEST_PATH: "kafka/ingest"
+  OPEN_POLICY_AGENT_KAFKA_INGEST_CONTENT_PATH: "kafka/ingest_content"
+  OPEN_POLICY_AGENT_KAFKA_INGEST_METADATA_PATH: "kafka/ingest_metadata"

--- a/helm/post-publication-combiner/values.yaml
+++ b/helm/post-publication-combiner/values.yaml
@@ -37,4 +37,4 @@ env:
   WHITELISTED_METADATA_ORIGIN_SYSTEM_HEADERS: "http://cmdb.ft.com/systems/pac, http://cmdb.ft.com/systems/next-video-editor"
   WHITELISTED_CONTENT_TYPES: "Article, Video, MediaResource, Audio, ContentPackage, LiveBlogPackage, LiveBlogPost, ContentCollection, ImageSet, Image, Graphic, LiveEvent, Clip, ClipSet, ,"
   OPEN_POLICY_AGENT_ADDRESS: "http://localhost:8181"
-  OPEN_POLICY_AGENT_POLICY_PATH: "post_publication_combiner/content_msg_evaluator"
+  OPEN_POLICY_AGENT_KAFKA_INGEST_PATH: "kafka/ingest"

--- a/main.go
+++ b/main.go
@@ -146,10 +146,15 @@ func main() {
 		Desc:   "Open policy agent sidecar address",
 		EnvVar: "OPEN_POLICY_AGENT_ADDRESS",
 	})
-	opaKafkaIngestPolicyPath := app.String(cli.StringOpt{
-		Name:   "opaKafkaIngestPolicyPath",
-		Desc:   "The path, inside the agent, to the Kafka Ingest OPA policy.",
-		EnvVar: "OPEN_POLICY_AGENT_KAFKA_INGEST_PATH",
+	opaKafkaIngestContentPolicyPath := app.String(cli.StringOpt{
+		Name:   "opaKafkaIngestContentPolicyPath",
+		Desc:   "The path, inside the agent, to the policy for Kafka ingestion of content.",
+		EnvVar: "OPEN_POLICY_AGENT_KAFKA_INGEST_CONTENT_PATH",
+	})
+	opaKafkaIngestMetadataPolicyPath := app.String(cli.StringOpt{
+		Name:   "opaKafkaIngestMetadataPolicyPath",
+		Desc:   "The path, inside the agent, to the policy for Kafka ingestion of metadata (annotations).",
+		EnvVar: "OPEN_POLICY_AGENT_KAFKA_INGEST_METADATA_PATH",
 	})
 
 	log := logger.NewUPPLogger(serviceName, *logLevel)
@@ -238,13 +243,14 @@ func main() {
 			}
 		}(producer)
 
-		paths := map[string]string{
-			policy.PackageName: *opaKafkaIngestPolicyPath,
+		policyPaths := map[string]string{
+			policy.KafkaIngestContent.String():  *opaKafkaIngestContentPolicyPath,
+			policy.KafkaIngestMetadata.String(): *opaKafkaIngestMetadataPolicyPath,
 		}
 
 		opaClient := opa.NewOpenPolicyAgentClient(
 			*openPolicyAgentAddress,
-			paths,
+			policyPaths,
 			opa.WithLogger(log),
 		)
 		opaAgent := policy.NewOpenPolicyAgent(opaClient, log)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,10 @@ const (
 )
 
 func main() {
-	app := cli.App(serviceName, "Service listening to content and metadata PostPublication events, and forwards a combined message to the queue")
+	app := cli.App(
+		serviceName,
+		"Service listening to content and metadata PostPublication events, and forwards a combined message to the queue",
+	)
 
 	logLevel := app.String(cli.StringOpt{
 		Name:   "logLevel",
@@ -112,8 +115,11 @@ func main() {
 		EnvVar: "CONTENT_COLLECTION_RW_ENDPOINT",
 	})
 	whitelistedMetadataOriginSystemHeaders := app.Strings(cli.StringsOpt{
-		Name:   "whitelistedMetadataOriginSystemHeaders",
-		Value:  []string{"http://cmdb.ft.com/systems/pac", "http://cmdb.ft.com/systems/next-video-editor"},
+		Name: "whitelistedMetadataOriginSystemHeaders",
+		Value: []string{
+			"http://cmdb.ft.com/systems/pac",
+			"http://cmdb.ft.com/systems/next-video-editor",
+		},
 		Desc:   "Origin-System-Ids that are supported to be processed from the PostPublicationEvents queue.",
 		EnvVar: "WHITELISTED_METADATA_ORIGIN_SYSTEM_HEADERS",
 	})
@@ -140,10 +146,10 @@ func main() {
 		Desc:   "Open policy agent sidecar address",
 		EnvVar: "OPEN_POLICY_AGENT_ADDRESS",
 	})
-	opaPolicyPath := app.String(cli.StringOpt{
-		Name:   "openPolicyAgentPolicyPath",
-		Desc:   "The path to the opa module in OPA module",
-		EnvVar: "OPEN_POLICY_AGENT_POLICY_PATH",
+	opaKafkaIngestPolicyPath := app.String(cli.StringOpt{
+		Name:   "opaKafkaIngestPolicyPath",
+		Desc:   "The path, inside the agent, to the Kafka Ingest OPA policy.",
+		EnvVar: "OPEN_POLICY_AGENT_KAFKA_INGEST_PATH",
 	})
 
 	log := logger.NewUPPLogger(serviceName, *logLevel)
@@ -205,7 +211,12 @@ func main() {
 		docStoreURL := *docStoreAPIBaseURL + *docStoreAPIEndpoint
 		internalContentURL := *internalContentAPIBaseURL + *internalContentAPIEndpoint
 		contentCollectionURL := *contentCollectionRWBaseURL + *contentCollectionRWEndpoint
-		dataCombiner := processor.NewDataCombiner(docStoreURL, internalContentURL, contentCollectionURL, client)
+		dataCombiner := processor.NewDataCombiner(
+			docStoreURL,
+			internalContentURL,
+			contentCollectionURL,
+			client,
+		)
 
 		producerConfig := kafka.ProducerConfig{
 			BrokersConnectionString: *kafkaAddress,
@@ -228,10 +239,14 @@ func main() {
 		}(producer)
 
 		paths := map[string]string{
-			policy.PackageName: *opaPolicyPath,
+			policy.PackageName: *opaKafkaIngestPolicyPath,
 		}
 
-		opaClient := opa.NewOpenPolicyAgentClient(*openPolicyAgentAddress, paths, opa.WithLogger(log))
+		opaClient := opa.NewOpenPolicyAgentClient(
+			*openPolicyAgentAddress,
+			paths,
+			opa.WithLogger(log),
+		)
 		opaAgent := policy.NewOpenPolicyAgent(opaClient, log)
 
 		processorConf := processor.NewMsgProcessorConfig(
@@ -270,7 +285,11 @@ func main() {
 			}
 		}(forcedMessageProducer)
 
-		proc := processor.NewRequestProcessor(dataCombiner, forcedMessageProducer, *whitelistedContentTypes)
+		proc := processor.NewRequestProcessor(
+			dataCombiner,
+			forcedMessageProducer,
+			*whitelistedContentTypes,
+		)
 
 		reqHandler := &requestHandler{
 			requestProcessor: proc,
@@ -278,7 +297,14 @@ func main() {
 		}
 
 		// Since the health check for all producers and consumers just checks /topics for a response, we pick a producer and a consumer at random
-		healthcheckHandler := NewCombinerHealthcheck(log, producer, consumer, client, *docStoreAPIBaseURL, *internalContentAPIBaseURL)
+		healthcheckHandler := NewCombinerHealthcheck(
+			log,
+			producer,
+			consumer,
+			client,
+			*docStoreAPIBaseURL,
+			*internalContentAPIBaseURL,
+		)
 
 		routeRequests(log, port, reqHandler, healthcheckHandler)
 	}

--- a/policy/agent.go
+++ b/policy/agent.go
@@ -11,7 +11,7 @@ import (
 var ErrEvaluatePolicy = errors.New("error evaluating policy")
 
 const (
-	PackageName = "content_msg_evaluator"
+	PackageName = "kafka_ingest"
 )
 
 type ContentPolicyResult struct {
@@ -20,7 +20,7 @@ type ContentPolicyResult struct {
 }
 
 type Agent interface {
-	EvaluateContentPolicy(q map[string]interface{}) (*ContentPolicyResult, error)
+	EvaluateKafkaIngestPolicy(q map[string]interface{}) (*ContentPolicyResult, error)
 }
 
 type OpenPolicyAgent struct {
@@ -35,7 +35,7 @@ func NewOpenPolicyAgent(c *opa.OpenPolicyAgentClient, l *logger.UPPLogger) *Open
 	}
 }
 
-func (o *OpenPolicyAgent) EvaluateContentPolicy(
+func (o *OpenPolicyAgent) EvaluateKafkaIngestPolicy(
 	q map[string]interface{},
 ) (*ContentPolicyResult, error) {
 	r := &ContentPolicyResult{}

--- a/policy/agent_test.go
+++ b/policy/agent_test.go
@@ -32,10 +32,14 @@ func TestAgent_EvaluateContentPolicy(t *testing.T) {
 			name: "Evaluate a Skipping Policy Decision",
 			server: createHTTPTestServer(
 				t,
-				fmt.Sprintf(`{"decision_id": %q, "result": {"skip": true, "reasons": [%q]}}`, testDecisionID, errMsgЕditorialDeskCB),
+				fmt.Sprintf(
+					`{"decision_id": %q, "result": {"skip": true, "reasons": [%q]}}`,
+					testDecisionID,
+					errMsgЕditorialDeskCB,
+				),
 			),
 			paths: map[string]string{
-				PackageName: "post_publication_combiner/content_msg_evaluator",
+				PackageName: "kafka/ingest",
 			},
 			query: map[string]interface{}{
 				"editorialDesk": "/FT/Professional/Central Banking", // This is informative and is not being used during test evaluation
@@ -53,7 +57,7 @@ func TestAgent_EvaluateContentPolicy(t *testing.T) {
 				fmt.Sprintf(`{"decision_id": %q, "result": {"skip": false}}`, testDecisionID),
 			),
 			paths: map[string]string{
-				PackageName: "post_publication_combiner/content_msg_evaluator",
+				PackageName: "kafka/ingest",
 			},
 			query: map[string]interface{}{
 				"editorialDesk": "/FT/Money", // This is informative and is not being used during test evaluation
@@ -85,7 +89,7 @@ func TestAgent_EvaluateContentPolicy(t *testing.T) {
 
 			o := NewOpenPolicyAgent(c, l)
 
-			result, err := o.EvaluateContentPolicy(test.query)
+			result, err := o.EvaluateKafkaIngestPolicy(test.query)
 
 			if err != nil {
 				if !errors.Is(err, test.expectedError) {

--- a/processor/msg_processor.go
+++ b/processor/msg_processor.go
@@ -174,12 +174,6 @@ func (p *MsgProcessor) processMetadataMsg(m kafka.FTMessage) {
 		log.Warn("Could not find internal content when processing an annotations publish event.")
 	}
 
-	uuid := combinedMSG.Content.getUUID()
-	if uuid == "" {
-		log.Warn("Skipped. Could not find content when processing an annotations publish event.")
-		return
-	}
-
 	result, err := p.opaAgent.EvaluateKafkaIngestPolicy(
 		combinedMSG.Content,
 		policy.KafkaIngestMetadata,
@@ -194,7 +188,7 @@ func (p *MsgProcessor) processMetadataMsg(m kafka.FTMessage) {
 		return
 	}
 
-	log = log.WithUUID(uuid)
+	log = log.WithUUID(combinedMSG.Content.getUUID())
 
 	if err = p.forwarder.filterAndForwardMsg(m.Headers, &combinedMSG); err != nil {
 		log.WithError(err).Error("Failed to forward message to Kafka")

--- a/processor/msg_processor.go
+++ b/processor/msg_processor.go
@@ -164,6 +164,8 @@ func (p *MsgProcessor) processMetadataMsg(m kafka.FTMessage) {
 		return
 	}
 
+	log.Info(fmt.Sprintf("Content URI: %s", ann.ContentURI))
+
 	combinedMSG, err := p.dataCombiner.GetCombinedModelForAnnotations(ann)
 	if err != nil {
 		log.WithError(err).

--- a/processor/msg_processor_test.go
+++ b/processor/msg_processor_test.go
@@ -31,6 +31,7 @@ type mockOpaAgent struct {
 
 func (m mockOpaAgent) EvaluateKafkaIngestPolicy(
 	_ map[string]interface{},
+	_ policy.Policy,
 ) (*policy.ContentPolicyResult, error) {
 	return m.returnResult, m.returnError
 }
@@ -422,6 +423,9 @@ func TestProcessMetadataMsg_Combiner_Errors(t *testing.T) {
 		"Error obtaining the combined message. Content couldn't get read. Message will be skipped.",
 		hook.LastEntry().Message,
 	)
+	for _, e := range hook.Entries {
+		fmt.Println(e.Message)
+	}
 	assert.Equal(t, 1, len(hook.Entries))
 }
 

--- a/processor/msg_processor_test.go
+++ b/processor/msg_processor_test.go
@@ -505,7 +505,10 @@ func TestProcessMetadataMsg_Forward_Skipped(t *testing.T) {
 	log, hook := testLogger()
 
 	opaAgent := mockOpaAgent{
-		returnResult: &policy.ContentPolicyResult{},
+		returnResult: &policy.ContentPolicyResult{
+			Skip:    true,
+			Reasons: []string{"Content UUID was not found. Message will be skipped"},
+		},
 	}
 
 	p := &MsgProcessor{
@@ -521,11 +524,11 @@ func TestProcessMetadataMsg_Forward_Skipped(t *testing.T) {
 
 	p.processMetadataMsg(m)
 
-	assert.Equal(t, "warning", hook.LastEntry().Level.String())
+	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "some-tid1", hook.LastEntry().Data["transaction_id"])
 	assert.Equal(
 		t,
-		"Skipped. Could not find content when processing an annotations publish event.",
+		"Content UUID was not found. Message will be skipped",
 		hook.LastEntry().Message,
 	)
 	assert.Equal(t, 2, len(hook.Entries))

--- a/processor/msg_processor_test.go
+++ b/processor/msg_processor_test.go
@@ -29,7 +29,9 @@ type mockOpaAgent struct {
 	returnError  error
 }
 
-func (m mockOpaAgent) EvaluateContentPolicy(_ map[string]interface{}) (*policy.ContentPolicyResult, error) {
+func (m mockOpaAgent) EvaluateKafkaIngestPolicy(
+	_ map[string]interface{},
+) (*policy.ContentPolicyResult, error) {
 	return m.returnResult, m.returnError
 }
 
@@ -93,7 +95,10 @@ func TestProcessContentMsg_Unmarshal_Error(t *testing.T) {
 }
 
 func TestProcessContentMsg_Combiner_Errors(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1"}, "./testData/content-null-type.json")
+	m, err := createMessage(
+		map[string]string{"X-Request-Id": "some-tid1"},
+		"./testData/content-null-type.json",
+	)
 	require.NoError(t, err)
 
 	cm := &ContentMessage{}
@@ -111,7 +116,12 @@ func TestProcessContentMsg_Combiner_Errors(t *testing.T) {
 		returnResult: &policy.ContentPolicyResult{},
 	}
 
-	p := &MsgProcessor{config: config, dataCombiner: dummyDataCombiner, log: log, opaAgent: opaAgent}
+	p := &MsgProcessor{
+		config:       config,
+		dataCombiner: dummyDataCombiner,
+		log:          log,
+		opaAgent:     opaAgent,
+	}
 
 	assert.Nil(t, hook.LastEntry())
 	assert.Equal(t, 0, len(hook.Entries))
@@ -120,13 +130,20 @@ func TestProcessContentMsg_Combiner_Errors(t *testing.T) {
 
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "some-tid1", hook.LastEntry().Data["transaction_id"])
-	assert.Equal(t, "Error obtaining the combined message. Metadata could not be read. Message will be skipped.", hook.LastEntry().Message)
+	assert.Equal(
+		t,
+		"Error obtaining the combined message. Metadata could not be read. Message will be skipped.",
+		hook.LastEntry().Message,
+	)
 	assert.Equal(t, dummyDataCombiner.err, hook.LastEntry().Data["error"])
 	assert.Equal(t, 1, len(hook.Entries))
 }
 
 func TestProcessContentMsg_Forwarder_Errors(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1"}, "./testData/content.json")
+	m, err := createMessage(
+		map[string]string{"X-Request-Id": "some-tid1"},
+		"./testData/content.json",
+	)
 	require.NoError(t, err)
 
 	cm := &ContentMessage{}
@@ -170,7 +187,10 @@ func TestProcessContentMsg_Forwarder_Errors(t *testing.T) {
 }
 
 func TestProcessContentMsg_Successfully_Forwarded(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1"}, "./testData/content.json")
+	m, err := createMessage(
+		map[string]string{"X-Request-Id": "some-tid1"},
+		"./testData/content.json",
+	)
 	require.NoError(t, err)
 
 	cm := &ContentMessage{}
@@ -231,7 +251,10 @@ func TestProcessContentMsg_Successfully_Forwarded(t *testing.T) {
 }
 
 func TestProcessContentMsg_DeleteEvent_Successfully_Forwarded(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1"}, "./testData/content-delete.json")
+	m, err := createMessage(
+		map[string]string{"X-Request-Id": "some-tid1"},
+		"./testData/content-delete.json",
+	)
 	require.NoError(t, err)
 
 	allowedContentTypes := []string{"Article", "Video"}
@@ -243,7 +266,8 @@ func TestProcessContentMsg_DeleteEvent_Successfully_Forwarded(t *testing.T) {
 			ContentURI:   "http://next-video-mapper.svc.ft.com/video/model/0cef259d-030d-497d-b4ef-e8fa0ee6db6b",
 			Deleted:      true,
 			LastModified: "2017-03-30T13:09:06.48Z",
-		}}
+		},
+	}
 
 	expMsg := kafka.FTMessage{
 		Headers: m.Headers,
@@ -283,14 +307,22 @@ func TestProcessContentMsg_DeleteEvent_Successfully_Forwarded(t *testing.T) {
 }
 
 func TestProcessMetadataMsg_UnSupportedOrigins(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "origin"}, "./testData/annotations.json")
+	m, err := createMessage(
+		map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "origin"},
+		"./testData/annotations.json",
+	)
 	require.NoError(t, err)
 
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service"}
 	config := MsgProcessorConfig{SupportedHeaders: allowedOrigins}
 
 	log, hook := testLogger()
-	p := &MsgProcessor{config: config, log: log}
+
+	opaAgent := mockOpaAgent{
+		returnResult: &policy.ContentPolicyResult{},
+	}
+
+	p := &MsgProcessor{config: config, log: log, opaAgent: opaAgent}
 
 	assert.Nil(t, hook.LastEntry())
 	assert.Equal(t, 0, len(hook.Entries))
@@ -300,21 +332,33 @@ func TestProcessMetadataMsg_UnSupportedOrigins(t *testing.T) {
 	assert.Equal(t, "info", hook.LastEntry().Level.String())
 	assert.Equal(t, "origin", hook.LastEntry().Data["originSystem"])
 	assert.Equal(t, "some-tid1", hook.LastEntry().Data["transaction_id"])
-	assert.Equal(t, "Skipped annotations with unsupported Origin-System-Id", hook.LastEntry().Message)
+	assert.Equal(
+		t,
+		"Skipped annotations with unsupported Origin-System-Id",
+		hook.LastEntry().Message,
+	)
 	assert.Equal(t, 1, len(hook.Entries))
 }
 
 func TestProcessMetadataMsg_SupportedOrigin_Unmarshal_Error(t *testing.T) {
 	m := kafka.FTMessage{
-		Headers: map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"},
-		Body:    `some body`,
+		Headers: map[string]string{
+			"X-Request-Id":     "some-tid1",
+			"Origin-System-Id": "http://cmdb.ft.com/systems/binding-service",
+		},
+		Body: `some body`,
 	}
 
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service"}
 	config := MsgProcessorConfig{SupportedHeaders: allowedOrigins}
 
 	log, hook := testLogger()
-	p := &MsgProcessor{config: config, log: log}
+
+	opaAgent := mockOpaAgent{
+		returnResult: &policy.ContentPolicyResult{},
+	}
+
+	p := &MsgProcessor{config: config, log: log, opaAgent: opaAgent}
 
 	assert.Nil(t, hook.LastEntry())
 	assert.Equal(t, 0, len(hook.Entries))
@@ -324,12 +368,22 @@ func TestProcessMetadataMsg_SupportedOrigin_Unmarshal_Error(t *testing.T) {
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "some-tid1", hook.LastEntry().Data["transaction_id"])
 	assert.Equal(t, "Could not unmarshal message", hook.LastEntry().Message)
-	assert.EqualError(t, hook.LastEntry().Data["error"].(error), "invalid character 's' looking for beginning of value")
+	assert.EqualError(
+		t,
+		hook.LastEntry().Data["error"].(error),
+		"invalid character 's' looking for beginning of value",
+	)
 	assert.Equal(t, 1, len(hook.Entries))
 }
 
 func TestProcessMetadataMsg_Combiner_Errors(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"}, "./testData/annotations.json")
+	m, err := createMessage(
+		map[string]string{
+			"X-Request-Id":     "some-tid1",
+			"Origin-System-Id": "http://cmdb.ft.com/systems/binding-service",
+		},
+		"./testData/annotations.json",
+	)
 	require.NoError(t, err)
 
 	am := &AnnotationsMessage{}
@@ -344,7 +398,17 @@ func TestProcessMetadataMsg_Combiner_Errors(t *testing.T) {
 	}
 
 	log, hook := testLogger()
-	p := &MsgProcessor{config: config, dataCombiner: dummyDataCombiner, log: log}
+
+	opaAgent := mockOpaAgent{
+		returnResult: &policy.ContentPolicyResult{},
+	}
+
+	p := &MsgProcessor{
+		config:       config,
+		dataCombiner: dummyDataCombiner,
+		log:          log,
+		opaAgent:     opaAgent,
+	}
 
 	assert.Nil(t, hook.LastEntry())
 	assert.Equal(t, 0, len(hook.Entries))
@@ -353,12 +417,22 @@ func TestProcessMetadataMsg_Combiner_Errors(t *testing.T) {
 
 	assert.Equal(t, "error", hook.LastEntry().Level.String())
 	assert.Equal(t, "some-tid1", hook.LastEntry().Data["transaction_id"])
-	assert.Equal(t, "Error obtaining the combined message. Content couldn't get read. Message will be skipped.", hook.LastEntry().Message)
+	assert.Equal(
+		t,
+		"Error obtaining the combined message. Content couldn't get read. Message will be skipped.",
+		hook.LastEntry().Message,
+	)
 	assert.Equal(t, 1, len(hook.Entries))
 }
 
 func TestProcessMetadataMsg_Forwarder_Errors(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"}, "./testData/annotations.json")
+	m, err := createMessage(
+		map[string]string{
+			"X-Request-Id":     "some-tid1",
+			"Origin-System-Id": "http://cmdb.ft.com/systems/binding-service",
+		},
+		"./testData/annotations.json",
+	)
 	require.NoError(t, err)
 
 	am := &AnnotationsMessage{}
@@ -374,7 +448,18 @@ func TestProcessMetadataMsg_Forwarder_Errors(t *testing.T) {
 	dummyMsgProducer := DummyProducer{t: t, expError: fmt.Errorf("some producer error")}
 
 	log, hook := testLogger()
-	p := &MsgProcessor{config: config, dataCombiner: dummyDataCombiner, forwarder: newForwarder(dummyMsgProducer, allowedContentTypes), log: log}
+
+	opaAgent := mockOpaAgent{
+		returnResult: &policy.ContentPolicyResult{},
+	}
+
+	p := &MsgProcessor{
+		config:       config,
+		dataCombiner: dummyDataCombiner,
+		forwarder:    newForwarder(dummyMsgProducer, allowedContentTypes),
+		log:          log,
+		opaAgent:     opaAgent,
+	}
 
 	assert.Nil(t, hook.LastEntry())
 	assert.Equal(t, 0, len(hook.Entries))
@@ -388,8 +473,15 @@ func TestProcessMetadataMsg_Forwarder_Errors(t *testing.T) {
 	assert.ErrorIs(t, hook.LastEntry().Data["error"].(error), dummyMsgProducer.expError)
 	assert.Equal(t, 2, len(hook.Entries))
 }
+
 func TestProcessMetadataMsg_Forward_Skipped(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"}, "./testData/annotations.json")
+	m, err := createMessage(
+		map[string]string{
+			"X-Request-Id":     "some-tid1",
+			"Origin-System-Id": "http://cmdb.ft.com/systems/binding-service",
+		},
+		"./testData/annotations.json",
+	)
 	require.NoError(t, err)
 
 	am := &AnnotationsMessage{}
@@ -398,12 +490,27 @@ func TestProcessMetadataMsg_Forward_Skipped(t *testing.T) {
 	allowedOrigins := []string{"http://cmdb.ft.com/systems/binding-service"}
 	allowedContentTypes := []string{"Article", "Video", ""}
 	config := MsgProcessorConfig{SupportedHeaders: allowedOrigins}
-	dummyDataCombiner := DummyDataCombiner{t: t, expectedMetadata: *am, data: CombinedModel{UUID: "some_uuid"}}
+	dummyDataCombiner := DummyDataCombiner{
+		t:                t,
+		expectedMetadata: *am,
+		data:             CombinedModel{UUID: "some_uuid"},
+	}
 	// The producer should return an error so that the test won't pass if the message forward is attempted
 	dummyMsgProducer := DummyProducer{t: t, expError: fmt.Errorf("some producer error")}
 
 	log, hook := testLogger()
-	p := &MsgProcessor{config: config, dataCombiner: dummyDataCombiner, forwarder: newForwarder(dummyMsgProducer, allowedContentTypes), log: log}
+
+	opaAgent := mockOpaAgent{
+		returnResult: &policy.ContentPolicyResult{},
+	}
+
+	p := &MsgProcessor{
+		config:       config,
+		dataCombiner: dummyDataCombiner,
+		forwarder:    newForwarder(dummyMsgProducer, allowedContentTypes),
+		log:          log,
+		opaAgent:     opaAgent,
+	}
 
 	assert.Nil(t, hook.LastEntry())
 	assert.Equal(t, 0, len(hook.Entries))
@@ -412,12 +519,22 @@ func TestProcessMetadataMsg_Forward_Skipped(t *testing.T) {
 
 	assert.Equal(t, "warning", hook.LastEntry().Level.String())
 	assert.Equal(t, "some-tid1", hook.LastEntry().Data["transaction_id"])
-	assert.Equal(t, "Skipped. Could not find content when processing an annotations publish event.", hook.LastEntry().Message)
+	assert.Equal(
+		t,
+		"Skipped. Could not find content when processing an annotations publish event.",
+		hook.LastEntry().Message,
+	)
 	assert.Equal(t, 2, len(hook.Entries))
 }
 
 func TestProcessMetadataMsg_Successfully_Forwarded(t *testing.T) {
-	m, err := createMessage(map[string]string{"X-Request-Id": "some-tid1", "Origin-System-Id": "http://cmdb.ft.com/systems/binding-service"}, "./testData/annotations.json")
+	m, err := createMessage(
+		map[string]string{
+			"X-Request-Id":     "some-tid1",
+			"Origin-System-Id": "http://cmdb.ft.com/systems/binding-service",
+		},
+		"./testData/annotations.json",
+	)
 	require.NoError(t, err)
 
 	am := &AnnotationsMessage{}
@@ -431,15 +548,24 @@ func TestProcessMetadataMsg_Successfully_Forwarded(t *testing.T) {
 		t:                t,
 		expectedMetadata: *am,
 		data: CombinedModel{
-			UUID:            "some_uuid",
-			Content:         ContentModel{"uuid": "some_uuid", "title": "simple title", "type": "Article"},
-			InternalContent: ContentModel{"uuid": "some_uuid", "title": "simple title", "type": "Article"},
+			UUID: "some_uuid",
+			Content: ContentModel{
+				"uuid":  "some_uuid",
+				"title": "simple title",
+				"type":  "Article",
+			},
+			InternalContent: ContentModel{
+				"uuid":  "some_uuid",
+				"title": "simple title",
+				"type":  "Article",
+			},
 			Metadata: []Annotation{
 				{
 					Thing: Thing{
 						ID:        "http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995",
 						PrefLabel: "Barclays",
-						Types: []string{"http://base-url/core/Thing",
+						Types: []string{
+							"http://base-url/core/Thing",
 							"http://base-url/concept/Concept",
 							"http://base-url/organisation/Organisation",
 							"http://base-url/company/Company",
@@ -450,7 +576,8 @@ func TestProcessMetadataMsg_Successfully_Forwarded(t *testing.T) {
 					},
 				},
 			},
-		}}
+		},
+	}
 	expMsg := kafka.FTMessage{
 		Headers: m.Headers,
 		Body:    `{"uuid":"some_uuid","contentUri":"","lastModified":"","deleted":false,"content":{"uuid":"some_uuid","title":"simple title","type":"Article"},"internalContent":{"uuid":"some_uuid","title":"simple title","type":"Article"},"metadata":[{"thing":{"id":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995","prefLabel":"Barclays","types":["http://base-url/core/Thing","http://base-url/concept/Concept","http://base-url/organisation/Organisation","http://base-url/company/Company","http://base-url/company/PublicCompany"],"predicate":"http://base-url/about","apiUrl":"http://base-url/80bec524-8c75-4d0f-92fa-abce3962d995"}}]}`,
@@ -464,11 +591,17 @@ func TestProcessMetadataMsg_Successfully_Forwarded(t *testing.T) {
 	}
 
 	log, hook := testLogger()
+
+	opaAgent := mockOpaAgent{
+		returnResult: &policy.ContentPolicyResult{},
+	}
+
 	p := &MsgProcessor{
 		config:       config,
 		dataCombiner: dummyDataCombiner,
 		forwarder:    newForwarder(dummyMsgProducer, allowedContentTypes),
 		log:          log,
+		opaAgent:     opaAgent,
 	}
 
 	assert.Nil(t, hook.LastEntry())
@@ -614,7 +747,12 @@ func TestSupports(t *testing.T) {
 
 	for _, testCase := range tests {
 		result := containsSubstringOf(testCase.array, testCase.element)
-		assert.Equal(t, testCase.expResult, result, fmt.Sprintf("Element %v was not found in %v", testCase.array, testCase.element))
+		assert.Equal(
+			t,
+			testCase.expResult,
+			result,
+			fmt.Sprintf("Element %v was not found in %v", testCase.array, testCase.element),
+		)
 	}
 }
 
@@ -646,7 +784,13 @@ func (p DummyProducer) SendMessage(m kafka.FTMessage) error {
 
 	assert.Equal(p.t, p.expTID, m.Headers["X-Request-Id"])
 
-	assert.True(p.t, reflect.DeepEqual(p.expMsg.Headers, m.Headers), "Expected: %v \nActual: %v", p.expMsg.Headers, m.Headers)
+	assert.True(
+		p.t,
+		reflect.DeepEqual(p.expMsg.Headers, m.Headers),
+		"Expected: %v \nActual: %v",
+		p.expMsg.Headers,
+		m.Headers,
+	)
 	assert.JSONEq(p.t, p.expMsg.Body, m.Body, "Expected: %v \nActual: %v", p.expMsg.Body, m.Body)
 
 	return nil
@@ -666,7 +810,9 @@ func (c DummyDataCombiner) GetCombinedModelForContent(content ContentModel) (Com
 	return c.data, c.err
 }
 
-func (c DummyDataCombiner) GetCombinedModelForAnnotations(metadata AnnotationsMessage) (CombinedModel, error) {
+func (c DummyDataCombiner) GetCombinedModelForAnnotations(
+	metadata AnnotationsMessage,
+) (CombinedModel, error) {
 	assert.Equal(c.t, c.expectedMetadata, metadata)
 	return c.data, c.err
 }


### PR DESCRIPTION
# Description

## What

This PR intends to fix an issue with the filtering of Central Banking content. The problem manifests itself when post-publication-combiner processes a message coming through its "Metadata flow". The changes in this PR add filtering for CB content in the aforementioned part of the service. They also use the new naming conventions of the actual OPA policy.

## Why

[JIRA](https://financialtimes.atlassian.net/browse/UPPSF-5360)

## Scope and particulars of this PR (Please tick all that apply)

- [ ] Tech hygiene (dependency updating & other tech debt)
- [x] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Breaking change
- [ ] Minor change (e.g. fixing a typo, adding config)
___
This Pull Request follows the rules described in our [Pull Requests Guide](https://github.com/Financial-Times/upp-docs/tree/master/guides/pr-guide)
